### PR TITLE
Improve Lyric Card Search

### DIFF
--- a/geniust/api.py
+++ b/geniust/api.py
@@ -304,6 +304,39 @@ class GeniusT(Genius):
                     return {"match": song}
             return {"match": None}
 
+    def page_data(self, album: str = None, song_id: int = None) -> dict:
+        """Gets page data of an item.
+
+        Page data will return all possible values for the album/song and
+        the lyrics in HTML format if the item is a song!
+        Album page data will contian album info and tracks info as well.
+
+        Args:
+            album (:obj:`str`, optional): Album path
+                (e.g. '/albums/Eminem/Music-to-be-murdered-by')
+            song_id (:obj:`int`, optional): Song ID.
+                (e.g. '/Sia-chandelier-lyrics')
+
+        Returns:
+            :obj:`dict`
+        """
+        assert any([album, song_id]), "You must pass either `song_id` or `album`."
+
+        if album:
+            endpoint = "page_data/album"
+            page_type = "albums"
+            item_path = album.replace("/albums/", "")
+        else:
+            endpoint = "page_data/song"
+            page_type = "songs"
+            item_path = str(song_id)
+        page_path = "/{page_type}/{item_path}".format(
+            page_type=page_type, item_path=item_path
+        )
+        params = {"page_path": page_path}
+
+        return self._make_request(endpoint, params_=params, public_api=True)
+
     def lyrics(
         self,
         song_id: int,

--- a/geniust/functions/inline_query.py
+++ b/geniust/functions/inline_query.py
@@ -20,8 +20,8 @@ from geniust.api import upload_to_imgbb
 from geniust.functions.lyric_card_builder import build_lyric_card
 from geniust.utils import (
     PERSIAN_CHARACTERS,
-    TRANSLATION_PARENTHESES,
     SECTION_HEADERS,
+    TRANSLATION_PARENTHESES,
     fix_section_headers,
     has_sentence,
     log,

--- a/geniust/functions/lyric_card.py
+++ b/geniust/functions/lyric_card.py
@@ -13,11 +13,11 @@ from geniust import get_user, username
 from geniust.constants import END, TYPING_LYRIC_CARD_CUSTOM, TYPING_LYRIC_CARD_LYRICS
 from geniust.functions.lyric_card_builder import build_lyric_card
 from geniust.utils import (
-    log,
-    fix_section_headers,
-    SECTION_HEADERS,
     PERSIAN_CHARACTERS,
+    SECTION_HEADERS,
     TRANSLATION_PARENTHESES,
+    fix_section_headers,
+    log,
 )
 
 logger = logging.getLogger("geniust")

--- a/geniust/functions/song.py
+++ b/geniust/functions/song.py
@@ -311,7 +311,7 @@ def display_lyrics(
     lyrics = re.sub(r"<[/]*(br|div|p).*[/]*?>", "", str(lyrics))
     # This adds a newline wherever the next section is separated from
     # the previous section with only one newline.
-    lyrics = re.sub(r"(?<!\n)\n\[", "\n\n[", lyrics)
+    lyrics = utils.fix_section_headers(lyrics)
 
     bot.delete_message(chat_id=chat_id, message_id=message_id)
 

--- a/geniust/utils.py
+++ b/geniust/utils.py
@@ -42,6 +42,10 @@ PERSIAN_CHARACTERS = re.compile(r"[\u0600-\u06FF]")
 # Translation phrase added to the end of the song title (more info at where it's used)
 TRANSLATION_PARENTHESES = re.compile(r"\([\u0600-\u06FF]\)")
 
+# Lyrics section headers e.e. \n[Chorus]\n
+SECTION_HEADERS = re.compile(r"\n{0,1}\[.*?\]\n{0,1}")
+FIX_SECTION_HEADERS = re.compile(r"(?<!\n)\n\[")
+
 # The keys are Telethon message entity types and the values PTB ones.
 MESSAGE_ENTITY_TYPES = {
     "MessageEntityBold": "bold",
@@ -153,6 +157,18 @@ def remove_links(s: str) -> str:
         str: formatted string.
     """
     return links_pattern.sub("", s)
+
+
+def fix_section_headers(string: str) -> str:
+    """Makes sure section headers have two newline characters before them
+
+    Args:
+        string (str): string.
+
+    Returns:
+        str: formatted string.
+    """
+    return FIX_SECTION_HEADERS.sub("\n\n[", string)
 
 
 def format_language(

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ pyasn1==0.4.8
 pycparser==2.20
 pyrsistent==0.17.3
 python-bidi==0.4.2
+python-Levenshtein==0.12.2
 python-telegram-bot==13.5
 pytz==2020.5
 PyYAML==5.4.1


### PR DESCRIPTION
# Changes
- Inline lyric card will now only return one image: the same one you'd get from `/lyric_card`.

# Minor Changes
- Instead of matching the input to the snippet and then the snippet to the lyrics which can get tricky, compare the lines by their Levenshtein ratio.

# Meta
- Added `python-levenshtein` to requirements. It's used to compare the strings in the lyric card functions. 